### PR TITLE
fix: sec patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.tgz
 *~
 .DS_Store
+.dccache

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": null,
+    "files": "./*/package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-07-22T17:14:58Z",
+  "generated_at": "2023-01-18T23:11:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,638 +70,796 @@
       {
         "hashed_secret": "72ef1a6c075efccc645b84629c9b23170288b4ef",
         "is_verified": false,
-        "line_number": 10,
+        "line_number": 1421,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "42159d8280931108aa5fd79ba75fb843f8ef5074",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 1431,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b3bbab1f0816092641893ccda9720e0343e385b5",
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 1440,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "8c53313323f4d695f5f6a359cacf12379a67a91e",
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 1451,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fc365cf01379e550b36a6994a3880e8b6b018954",
+        "is_verified": false,
+        "line_number": 1461,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "0583de1a919a122c171a45da7623d0b248921ceb",
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 1470,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "6d0e2933ecfe11c9e87a3413b950ece209578a44",
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 1476,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "4b6eccc2ffcf3e0eb3b843d58916d458a698611d",
+        "hashed_secret": "2b4922081b47a69c1a1a3c0f7946223015e1fc6d",
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 1482,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b8e8ea78154352778ce6c41eb733ea459cbca784",
         "is_verified": false,
-        "line_number": 68,
+        "line_number": 1488,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "76d2249ba356abb1bc625726cfb043aa796daf5a",
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 1494,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "a896da46c897d3a0d007843006621f78dbcabf51",
+        "hashed_secret": "89c31fa0d6838019bc29341b448d189aa712045b",
         "is_verified": false,
-        "line_number": 84,
+        "line_number": 1504,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "533be81726e04db6fb3f3cd0ce58b4bc07b15877",
         "is_verified": false,
-        "line_number": 93,
+        "line_number": 1513,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "6ebe9724873357aaea25e329efb726fa61b843e7",
         "is_verified": false,
-        "line_number": 111,
+        "line_number": 1531,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "1addd61f68d977408128e530959437821a6d8b66",
+        "hashed_secret": "a6f48bf1e398deffc7fd31da17c3506b46c97a93",
         "is_verified": false,
-        "line_number": 116,
+        "line_number": 1536,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "56fbae787f4aed7d0632e95840d71bd378d3a36f",
+        "is_verified": false,
+        "line_number": 1544,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "fba68bf276811b526b9b49682c437d658a6c215f",
         "is_verified": false,
-        "line_number": 124,
+        "line_number": 1549,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "301ef1a56628a2d7b47ce6e6486bf04f8b6ff1f6",
+        "hashed_secret": "3901f9835a898bc8ec6e92ccca8ae9f69d9c3862",
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 1559,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "456d02ad0d4d84a2516934ac4cd212b702a35971",
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 1576,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "92b56edda4f2906f548fe77c015490e6ba2ee4c3",
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 1582,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "69ec1176188646523a580e460881be7541e091ae",
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 1587,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "abef20c77330dd46ff3c9149ba1270c2097fe121",
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 1595,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "4bad86c43b7cd06efc130272d8e4de2b32636371",
+        "hashed_secret": "c4e5cc37e115bf7d86e76e3d799705bf691e4d00",
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 1603,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "3aafb400e42871c4a994eba8013e4ff1034c2724",
         "is_verified": false,
-        "line_number": 194,
+        "line_number": 1637,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "0512e37fbedf1d16828680a038a241b4780a5c04",
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 1647,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "0cc93dfdf4ae08bc374b99af985b25d2427f71d8",
+        "hashed_secret": "c61921cb03b0d17c9d180fa6d2d765269458f5e9",
         "is_verified": false,
-        "line_number": 214,
+        "line_number": 1657,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "81cb6be182eb79444202c4563080aee75296a672",
+        "is_verified": false,
+        "line_number": 1662,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "26f76deebe03d118284ce3a2b105ef284a3af65b",
         "is_verified": false,
-        "line_number": 219,
+        "line_number": 1671,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "c96d81662cc7919208154e7152fa0033391b7bcd",
+        "hashed_secret": "f52956fa7c317746fde250d0f4e54d6115252cd4",
         "is_verified": false,
-        "line_number": 225,
+        "line_number": 1677,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "7156492f40fb2479a45780b3d2959c29b27b6374",
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 1692,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "885304335818f51938422166d361cddacfd626d0",
+        "hashed_secret": "ac44c0200331f017448182940197aa959f169c77",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 1697,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "915ca894a8ec19ffcd55555e6c8daac1fe882751",
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 1702,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dac0640634507d1e51d1abb71fad3023e8efe72c",
+        "is_verified": false,
+        "line_number": 1712,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
         "is_verified": false,
-        "line_number": 253,
+        "line_number": 1721,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "f883f0bd87d8455814f491e2067bd3f62454c7c2",
         "is_verified": false,
-        "line_number": 261,
+        "line_number": 1729,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b4c295435d09bbdfb91ced9040379166d67ccbd2",
         "is_verified": false,
-        "line_number": 268,
+        "line_number": 1736,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "bb2bf296d6e086b471d45a26af9fd57f55289a75",
+        "hashed_secret": "572b5e5253ab86ef535e76d891766cc1a17ee6a5",
         "is_verified": false,
-        "line_number": 273,
+        "line_number": 1741,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "21194e556cc6a23d3903b12189b0b9cd1050f2e5",
+        "is_verified": false,
+        "line_number": 1751,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "dc79c293824667a1965d4136b3615840c57e2990",
         "is_verified": false,
-        "line_number": 288,
+        "line_number": 1756,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "7e280af4ec2d573144d98e89ed2e1dfd817ca48f",
+        "hashed_secret": "cc0394ae9ff7278ac1f8ba8305e06627798ae34b",
         "is_verified": false,
-        "line_number": 296,
+        "line_number": 1764,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "941b3e7836a6f26d32311893ac5d9ad0a52c45ca",
+        "hashed_secret": "3b9b4f0e0dc452a1ab51ff9a7e649171b0b54a70",
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 1769,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "c4fea87bd49c4427d7215d57ada9ff3177e0c471",
         "is_verified": false,
-        "line_number": 306,
+        "line_number": 1774,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "85324324e21d0dfbfb5248ac92fa0f289d2e25f8",
+        "hashed_secret": "7098a3e6d6d2ec0a40f04fe12509c5c6f4c49c0e",
         "is_verified": false,
-        "line_number": 311,
+        "line_number": 1779,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "ebe2160ede628e0faeac9fe70c215cd38d28d8f6",
+        "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
         "is_verified": false,
-        "line_number": 348,
+        "line_number": 1830,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "31a41817127c8d2b7b304c326b05d7319934e7a6",
+        "hashed_secret": "319c826dc43095ba30f620db4e9ee05f414b8d6d",
         "is_verified": false,
-        "line_number": 362,
+        "line_number": 1837,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "150852e9f1e877547306d59618a136fb535b40e3",
+        "hashed_secret": "32b21734f6e558872707a9a486a46507deda8307",
         "is_verified": false,
-        "line_number": 367,
+        "line_number": 1861,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dc9a2ba629796d6ef3323496eb952461f964e115",
+        "is_verified": false,
+        "line_number": 1869,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "67e1630eef767c17f165bed8793abff78d5d53ac",
+        "is_verified": false,
+        "line_number": 1874,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "12ffe31fe2cdc41991054eec09b2a8e1105b126e",
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 1879,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "11bc2d99c3f7858920753a3e46ddbb0d9e781e9f",
+        "is_verified": false,
+        "line_number": 1885,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f0f3f7bce32184893046ac5f8cc80da56c3ca539",
+        "is_verified": false,
+        "line_number": 1890,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "6f9f90d5c3121e1d187582da18b59b8d0e2fbf2e",
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 1900,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "98eafa06e0c7e089c19e79dedf5989c3eb2f0568",
+        "hashed_secret": "9338f3fa6edf38b34ba03eb64ab4225ae72123f0",
         "is_verified": false,
-        "line_number": 392,
+        "line_number": 1914,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f8feccd17eb37adbde0e41eb186cf32c382ca9bf",
+        "is_verified": false,
+        "line_number": 1922,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "097893233346336f4003acfb6eb173ee59e648f0",
+        "is_verified": false,
+        "line_number": 1930,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb14c3b4ef4a9f2e86ffdd44b88d9b6729419671",
+        "is_verified": false,
+        "line_number": 1935,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "512c14acc52a5552e7c6a902a15f052e31b7972f",
+        "is_verified": false,
+        "line_number": 1943,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ebf396301cd5f2bffdd5e7e25066a15ea189798d",
+        "is_verified": false,
+        "line_number": 1948,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "768c25729bb5f793948b6f5cf680be00a708e1dd",
         "is_verified": false,
-        "line_number": 411,
+        "line_number": 1967,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "8ecd6866e9580d7008fe74a0650b5440071194a6",
         "is_verified": false,
-        "line_number": 420,
+        "line_number": 1976,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "3e6c18abd5b90c63da0bd8b4c0d3a142e3d5a83d",
         "is_verified": false,
-        "line_number": 430,
+        "line_number": 1986,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "209bf9cfe9000c6851cd4f94165d30ee1cd3dca1",
         "is_verified": false,
-        "line_number": 438,
+        "line_number": 1994,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 2009,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "575c9b4e0765ae6ab9a4f38eb1186ea361691f73",
+        "hashed_secret": "89b283ab50bf537dfbd64a59830fb7dda89eb546",
         "is_verified": false,
-        "line_number": 458,
+        "line_number": 2014,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "71344a35cff67ef081920095d1406601fb5e9b97",
+        "is_verified": false,
+        "line_number": 2019,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb2beaa7a8684460bbeeb734af599cfb5802456d",
+        "is_verified": false,
+        "line_number": 2028,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "39cffdcad4e8d13b5425560b57f318986bcfde7f",
         "is_verified": false,
-        "line_number": 463,
+        "line_number": 2033,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "eb3db6990fd43477a35dfeffc90b3f1ffa83c7bd",
+        "is_verified": false,
+        "line_number": 2038,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "266288bdc14807b538d1e48a5891e361fa9b4a14",
+        "is_verified": false,
+        "line_number": 2046,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "80d73b6f7e87f07e3ae70ef1e692aa9569574551",
         "is_verified": false,
-        "line_number": 468,
+        "line_number": 2058,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "feaca202f7f2c780d9d2d3e9a85ac7bcecaf8e5a",
         "is_verified": false,
-        "line_number": 473,
+        "line_number": 2063,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "c49b94dd3e0367e95c1d89f5ea2012a2375b5daf",
         "is_verified": false,
-        "line_number": 483,
+        "line_number": 2073,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "150b60d278251f2470dd690016afe038bc1bb7f1",
+        "hashed_secret": "797d4751c536c421cb82b9f62e0a804af30d78f5",
         "is_verified": false,
-        "line_number": 489,
+        "line_number": 2079,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "b0819ab93327fea1db86da7163d82c41b9f71508",
+        "hashed_secret": "e9fdc3025cd10bd8aa4508611e6b7b7a9d650a2c",
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 2084,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "cbc4e5dde66a391c6bca6ebbfab855d78a90e9cc",
         "is_verified": false,
-        "line_number": 499,
+        "line_number": 2089,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "3257be5e0dc94fe5ea8e1b69faffa81daa10943d",
         "is_verified": false,
-        "line_number": 504,
+        "line_number": 2094,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "af078acfe7bc52ead9db77bf9149363b78e0c668",
         "is_verified": false,
-        "line_number": 509,
+        "line_number": 2099,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "f4ead8a29448966a9dbff855bc058b85735d91b0",
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 2104,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "2e1c190a76e77abe1a33d3ea5203d1c2a4418604",
         "is_verified": false,
-        "line_number": 519,
+        "line_number": 2109,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "7f86ff773e1da8b55f609f57097790c3eea34699",
         "is_verified": false,
-        "line_number": 524,
+        "line_number": 2114,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "06a3dc8802aa9b4f2f48ad081cbe64482ce9f491",
+        "hashed_secret": "d7c39664c403d1fecb3d1e330ad65a00bab67629",
         "is_verified": false,
-        "line_number": 529,
+        "line_number": 2119,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "6c8453f18e4aa0280d847454c9a803c12e2d14d7",
         "is_verified": false,
-        "line_number": 534,
+        "line_number": 2124,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "3df46004e168f8d8e3422adfbf0b7c237a41f437",
         "is_verified": false,
-        "line_number": 539,
+        "line_number": 2129,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5c270f653b2fcd5b7c700b53f8543df4147a4aba",
         "is_verified": false,
-        "line_number": 544,
+        "line_number": 2134,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "98a159a135963e5e65a546879c332b2c3942aec3",
+        "hashed_secret": "838abb1331a160bdd441c25a2a2d44332ee8694b",
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 2139,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "58d846ede841bbec0d67a42d03426806635fee2f",
+        "hashed_secret": "e6525dbd438fc8858b0d56c59d164f403792ba1e",
         "is_verified": false,
-        "line_number": 554,
+        "line_number": 2144,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "67619a42987e368dd3fe59582e4e13c12e7a563d",
+        "hashed_secret": "b701486290777985572bdf83321be59eee7cd0c6",
         "is_verified": false,
-        "line_number": 562,
+        "line_number": 2152,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "7b886dd5dffbe92ceb17bef8b2d44cedb45b79b8",
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 2161,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "ea7a290ccb099ca955bf01c7b1203e4930a1f79a",
+        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
         "is_verified": false,
-        "line_number": 583,
+        "line_number": 2173,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "8ece0f01da9189bae69a60da116040400bbc10e5",
+        "hashed_secret": "4882a3f560bc1bf6d57e2e0d1bf68d2568e76dae",
         "is_verified": false,
-        "line_number": 588,
+        "line_number": 2178,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
+        "is_verified": false,
+        "line_number": 2183,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ebeb5b574fa1ed24a40248275e6136759e766466",
+        "is_verified": false,
+        "line_number": 2188,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "baac57cb314beab87420d1da6906a1d2377c7d73",
         "is_verified": false,
-        "line_number": 593,
+        "line_number": 2193,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "7966be01ab9657cf6ff1cf1d4be2d8e1b46359bd",
         "is_verified": false,
-        "line_number": 601,
+        "line_number": 2201,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "ae745d719f97b3ddb9791348b1f29ff8208c0c5c",
         "is_verified": false,
-        "line_number": 615,
+        "line_number": 2215,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "891e23c02f7af11c912b47e84dba9ebc2a810571",
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 2220,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b72a53c8bebd6540eeffeba5b0c28965bbb2a664",
         "is_verified": false,
-        "line_number": 626,
+        "line_number": 2226,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "bc98c415b1c6ee93adf8e97a4a536b6342337c19",
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 2231,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "5a6baaacb03a030567b857cb8cfe440407e6385e",
+        "hashed_secret": "2a416cdbfc3b4651a6d04d447938ace3ff9c7b6a",
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 2236,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "dd5ea12fc9e7e04ed77e6035faf82e6038d74874",
         "is_verified": false,
-        "line_number": 645,
+        "line_number": 2245,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5782d0f39536b22f2c6aa29d3b815a57f43e4800",
         "is_verified": false,
-        "line_number": 650,
+        "line_number": 2250,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "19eea0e64f6a3311b04e472035df10c23f23dd0a",
+        "hashed_secret": "ee161bb3f899720f95cee50a5f9ef9c9ed96278b",
         "is_verified": false,
-        "line_number": 655,
+        "line_number": 2255,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "51f38b23af543da8b637a3bd62f5fb2c460e3b3d",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 2263,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "8287678ab8009ae16b02930c9e260d1f28578fbe",
         "is_verified": false,
-        "line_number": 665,
+        "line_number": 2268,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "d4c050e6914eb68a5c657fb8bb09f6ac5eae1e86",
+        "hashed_secret": "c9b541d735c47302bcfd3067d42d59b976283212",
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 2273,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b346e156f821caf8b02240495a2d9a1dbe429fd4",
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 2284,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b8b89e678f1c53dcae04da0b6a85a581fe525a66",
         "is_verified": false,
-        "line_number": 695,
+        "line_number": 2298,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "d5e822897b1f37e6ce1a864e2ba9af8f9bfc5539",
         "is_verified": false,
-        "line_number": 716,
+        "line_number": 2319,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
         "is_verified": false,
-        "line_number": 721,
+        "line_number": 2324,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "12917e7235ce486ca51a296b896afa5e3b4fda54",
         "is_verified": false,
-        "line_number": 726,
+        "line_number": 2329,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "49e05eb75fd04d8f44cf235d4e8eddc30a2b93e5",
+        "hashed_secret": "9a4894f8dde7323e575b9cb11c18c20fe7c59c37",
         "is_verified": false,
-        "line_number": 731,
+        "line_number": 2334,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "aa8ea120ddc5aaa27cb02e0b04ac1c53b249a724",
+        "hashed_secret": "c5deff9c59d0e0419952da44431546620804d70e",
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 2354,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "b3e00452fd69737cc747d0661fa3b3949a4a0805",
+        "hashed_secret": "1fd960f79ff7ccd39310bfdf81fba2b2663b71d0",
         "is_verified": false,
-        "line_number": 758,
+        "line_number": 2359,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "af2ceb518ddc689b0e2a03ffebb64d4499817c17",
+        "hashed_secret": "7b07d556fa6f77a7e2bc54a89cfbebc93fab96a9",
         "is_verified": false,
-        "line_number": 769,
+        "line_number": 2369,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bae67d3ce231086fba18abc7365c94878f900c14",
+        "is_verified": false,
+        "line_number": 2380,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a6a555a428522ccf439fd516ce7c7e269274363f",
+        "is_verified": false,
+        "line_number": 2385,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "d9657545753aac21f43fb117cef14942688f6e22",
         "is_verified": false,
-        "line_number": 774,
+        "line_number": 2395,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "20249a3c96028e5ad19143d86ec5d2ee233935ed",
+        "hashed_secret": "6057a244d926cc3fac60c38cc276e3a75c45e178",
         "is_verified": false,
-        "line_number": 782,
+        "line_number": 2403,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "2a57a9814486d6f83257ec94e65d1024819611b8",
         "is_verified": false,
-        "line_number": 787,
+        "line_number": 2408,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "b0cb4b5554183f2c7bc1ca25d902db5769798a7a",
+        "hashed_secret": "a6d813aa7164341218d80a2b625ff1b254fa10c3",
         "is_verified": false,
-        "line_number": 795,
+        "line_number": 2416,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "955d2d24c472b4eb0b4488f935a0f65e38001df8",
         "is_verified": false,
-        "line_number": 800,
+        "line_number": 2421,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "a21faae2b0088d3efe88e1b609223854bab92e54",
         "is_verified": false,
-        "line_number": 809,
+        "line_number": 2430,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "292b56ccb1313ea50f4d1bf0efc7f2b04670fe73",
+        "is_verified": false,
+        "line_number": 2436,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "a43c7ca9ef987cf0886eef70236f3f19f2db08cc",
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 2450,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f74135fdd6b8dafdfb01ebbc61c5e5c24ee27cf8",
+        "is_verified": false,
+        "line_number": 2455,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "7fbf450bf4ee54f013454f70af3a9743c0909f54",
         "is_verified": false,
-        "line_number": 834,
+        "line_number": 2467,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "df8e0babfad52a541f6e470cf3a143402c2c2a1e",
         "is_verified": false,
-        "line_number": 839,
+        "line_number": 2472,
         "type": "Base64 High Entropy String"
       },
       {
-        "hashed_secret": "6f9bfb49cb818d2fe07592515e4c3f7a0bbd7e0e",
+        "hashed_secret": "3f0c251b9c2c21454445a98fde6915ceacde2136",
         "is_verified": false,
-        "line_number": 844,
+        "line_number": 2477,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "800477261175fd21f23e7321923e1fba6ae55471",
+        "is_verified": false,
+        "line_number": 2487,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "eca5fc6e4f5f895143d3fcedefc42dfe6e79f918",
         "is_verified": false,
-        "line_number": 854,
+        "line_number": 2500,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "307a947aa422c67fdefb07178198a004fb2c0d94",
         "is_verified": false,
-        "line_number": 860,
+        "line_number": 2506,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "0ba2fc9a137313ae1fdda2b5476dedf0595bda3a",
         "is_verified": false,
-        "line_number": 869,
+        "line_number": 2515,
         "type": "Base64 High Entropy String"
+      }
+    ],
+    "src/@gen3/statics/lib/configHelper.ts": [
+      {
+        "hashed_secret": "c2543fff3bfa6f144c2f06a7de6cd10c0b650cae",
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Secret Keyword"
       }
     ],
     "src/@gen3/statics/spec/creds.json": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gen3-statics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gen3-statics",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-config": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,16 @@
       "dependencies": {
         "aws-config": "^1.4.0",
         "aws-sdk": "^2.702.0",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
+        "helmet": "^6.0.1",
         "morgan": "^1.9.1",
         "s3-proxy": "^1.2.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.1",
         "@types/jasmine": "^3.4.0",
-        "@types/node": "^12.7.2",
+        "@types/node": "^12.20.55",
         "jasmine": "^3.4.0",
         "jasmine-core": "^3.4.0",
         "typescript": "latest"
@@ -77,9 +79,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
-      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -357,6 +359,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -650,6 +664,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -954,6 +976,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1656,6 +1686,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1877,6 +1916,11 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "helmet": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -2112,6 +2156,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -2356,9 +2405,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "unpipe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.1",
+        "@types/helmet": "^4.0.0",
         "@types/jasmine": "^3.4.0",
         "@types/node": "^12.20.55",
         "jasmine": "^3.4.0",
@@ -64,6 +65,16 @@
       "dependencies": {
         "@types/node": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/helmet": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/helmet/-/helmet-4.0.0.tgz",
+      "integrity": "sha512-ONIn/nSNQA57yRge3oaMQESef/6QhoeX7llWeDli0UZIfz8TQMkfNPTXA8VnnyeA1WUjG2pGqdjEIueYonMdfQ==",
+      "deprecated": "This is a stub types definition. helmet provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "helmet": "*"
       }
     },
     "node_modules/@types/jasmine": {
@@ -1442,6 +1453,15 @@
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/helmet": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/helmet/-/helmet-4.0.0.tgz",
+      "integrity": "sha512-ONIn/nSNQA57yRge3oaMQESef/6QhoeX7llWeDli0UZIfz8TQMkfNPTXA8VnnyeA1WUjG2pGqdjEIueYonMdfQ==",
+      "dev": true,
+      "requires": {
+        "helmet": "*"
       }
     },
     "@types/jasmine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gen3-statics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "S3 read-through proxy",
   "main": "express.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.1",
+    "@types/helmet": "^4.0.0",
     "@types/jasmine": "^3.4.0",
     "@types/node": "^12.20.55",
     "jasmine": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
   },
   "homepage": "https://github.com/uc-cdis/gen3-statics#readme",
   "dependencies": {
+    "aws-config": "^1.4.0",
     "aws-sdk": "^2.702.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
+    "helmet": "^6.0.1",
     "morgan": "^1.9.1",
-    "s3-proxy": "^1.2.1",
-    "aws-config": "^1.4.0"
+    "s3-proxy": "^1.2.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.1",

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,7 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "default-src": null,
+        "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
         "img-src": null,
         "script-src": null
       },

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,10 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
-        "img-src": null,
-        "script-src": null,
-        "script-src-attr": null
+        "script-src": "'self' 'unsafe-inline'"
       },
     }
   }));

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,7 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "script-src": "'self' 'unsafe-inline'"
+        "script-src": ["'self'", "'unsafe-inline'"]
       },
     }
   }));

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -1,7 +1,7 @@
 import fs = require('fs');
 import * as express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
+import * as cors from 'cors';
+import * as helmet from 'helmet';
 import s3Proxy = require('s3-proxy');
 
 import {loadConfig, processArgs, LaunchConfig, ProxyConfig} from '../lib/configHelper';
@@ -13,7 +13,7 @@ function launchServer(configFolder:string) {
   // enable logging
   app.use(require('morgan')('dev'));
   app.use(cors());
-  app.use(helmet());
+  app.use(helmet.default());
 
   loadConfig(configFolder).then(
     (config:ProxyConfig) => {

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,6 +16,8 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
+        "default-src": null,
+        "img-src": null,
         "script-src": null
       },
     }

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,7 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "script-src": ["'self'", "'unsafe-inline'", "https://code.jquery.com", "https://cdnjs.cloudflare.com"],
+        "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com"],
         "script-src-attr": null,
       },
     }

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,7 +16,8 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "script-src": ["'self'", "'unsafe-inline'"]
+        "script-src": ["'self'", "'unsafe-inline'", "https://code.jquery.com", "https://cdnjs.cloudflare.com"],
+        "script-src-attr": null,
       },
     }
   }));

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,6 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
+        // modify this section for new remote script needs
         "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com", "https://unpkg.com"],
         "script-src-attr": null,
       },

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -1,5 +1,7 @@
 import fs = require('fs');
 import * as express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
 import s3Proxy = require('s3-proxy');
 
 import {loadConfig, processArgs, LaunchConfig, ProxyConfig} from '../lib/configHelper';
@@ -10,6 +12,8 @@ function launchServer(configFolder:string) {
 
   // enable logging
   app.use(require('morgan')('dev'));
+  app.use(cors());
+  app.use(helmet());
 
   loadConfig(configFolder).then(
     (config:ProxyConfig) => {

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,7 +16,8 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com", "https://unpkg.com"],
+        "script-src": null,
+        // "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com", "https://unpkg.com"],
         "script-src-attr": null,
       },
     }

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -4,24 +4,30 @@ import * as cors from 'cors';
 import * as helmet from 'helmet';
 import s3Proxy = require('s3-proxy');
 
-import {loadConfig, processArgs, LaunchConfig, ProxyConfig} from '../lib/configHelper';
+import { loadConfig, processArgs, LaunchConfig, ProxyConfig } from '../lib/configHelper';
 
 
-function launchServer(configFolder:string) {
+function launchServer(configFolder: string) {
   const app = express();
 
   // enable logging
   app.use(require('morgan')('dev'));
   app.use(cors());
-  app.use(helmet.default());
+  app.use(helmet.default({
+    contentSecurityPolicy: {
+      directives: {
+        "script-src": null
+      },
+    }
+  }));
 
   loadConfig(configFolder).then(
-    (config:ProxyConfig) => {
+    (config: ProxyConfig) => {
       const logger = process.env.DEBUG ? console : undefined;
-      app.get('/*', s3Proxy({ logger, ... config }));
-      app.listen(4000, function() {
+      app.get('/*', s3Proxy({ logger, ...config }));
+      app.listen(4000, function () {
         console.log('Server listening at http://localhost:4000/');
-      });    
+      });
     }
   );
 }
@@ -36,7 +42,7 @@ function help() {
 // main --------------
 
 console.log(process.argv);
-const launchConfig:LaunchConfig = processArgs(process.argv.slice(2))
+const launchConfig: LaunchConfig = processArgs(process.argv.slice(2))
 
 if (launchConfig.command == 'launch') {
   launchServer(launchConfig.options['configFolder']);

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,8 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "script-src": null,
-        // "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com", "https://unpkg.com"],
+        "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com", "https://unpkg.com"],
         "script-src-attr": null,
       },
     }

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -16,7 +16,7 @@ function launchServer(configFolder: string) {
   app.use(helmet.default({
     contentSecurityPolicy: {
       directives: {
-        "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com"],
+        "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://code.jquery.com", "https://cdnjs.cloudflare.com", "https://unpkg.com"],
         "script-src-attr": null,
       },
     }

--- a/src/@gen3/statics/bin/server.ts
+++ b/src/@gen3/statics/bin/server.ts
@@ -18,7 +18,8 @@ function launchServer(configFolder: string) {
       directives: {
         "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
         "img-src": null,
-        "script-src": null
+        "script-src": null,
+        "script-src-attr": null
       },
     }
   }));

--- a/src/@gen3/statics/lib/configHelper.ts
+++ b/src/@gen3/statics/lib/configHelper.ts
@@ -50,6 +50,7 @@ export function loadConfig(configFolder:string):Promise<ProxyConfig> {
       bucket: config.bucket || '$BUCKET',
       prefix: config.prefix || '$HOSTNAME',
       accessKeyId: (config.AWS && config.AWS.id) || '$AWS_ACCESS_KEY_ID',
+      // file deepcode ignore HardcodedNonCryptoSecret: this is not a secret
       secretAccessKey: (config.AWS && config.AWS.secret) || '$AWS_SECRET_ACCESS_KEY',
       overrideCacheControl: 'max-age=300',
       defaultKey: '',


### PR DESCRIPTION
Jira Ticket: [PPS-154](https://ctds-planx.atlassian.net/browse/PPS-154)


### Improvements
- Add CSP directives in response

### Dependency updates
- Adpoted `helmet`
- Adpoted `cors`

### Deployment changes
- This change will add some CSP and CORS related header to the response that returned from the dashboard services. They should not be interruptive, but each team is encouraged to double check their webpages hosted by dashboard to ensure they still works
- Because of these CSP directives being added, starting from this version, if anyone what to load remote scripts in their dashboard-hosted webpages, they will need to update the CSP directives in this dashboard service if the current directives doesn't fit, or to ship the script files with the page


[PPS-154]: https://ctds-planx.atlassian.net/browse/PPS-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ